### PR TITLE
Fix for error when using stdin as input on Windows

### DIFF
--- a/luadec/luadec.c
+++ b/luadec/luadec.c
@@ -344,6 +344,9 @@ int luaU_guess_locals(Proto * f, int main);
 
 int main(int argc, char* argv[])
 {
+#if defined(_WIN32)
+	_setmode(0, 0x8000);
+#endif
 	int oargc;
 	char** oargv;
 	char tmp[256];


### PR DESCRIPTION
This is needed to tell Windows to read stdin (0) in binary (0x8000) mode. Without this, it interprets ^Z as the end of stdin.